### PR TITLE
Extending Command Manager window + Code cleanup

### DIFF
--- a/src/main/java/edu/kis/powp/jobs2d/command/gui/CommandManagerWindow.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/gui/CommandManagerWindow.java
@@ -168,7 +168,7 @@ public class CommandManagerWindow extends JFrame implements WindowComponent {
 
     private void runCommand(){
         if (commandManager.getCurrentCommand() == null) return;
-        commandManager.getCurrentCommand().execute(commandManager.getDriver());
+        commandManager.runCommand();
     }
 
     private void toggleButtons(JButton button) {

--- a/src/main/java/edu/kis/powp/jobs2d/command/gui/CommandManagerWindow.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/gui/CommandManagerWindow.java
@@ -100,9 +100,14 @@ public class CommandManagerWindow extends JFrame implements WindowComponent {
         buttonConstraints.weightx = 1;
         buttonConstraints.gridx = 0;
 
+        JButton btnRunCommand = new JButton("Run command");
+        btnRunCommand.addActionListener((ActionEvent e) -> this.runCommand());
+        buttonConstraints.gridy = 0;
+        buttonPanel.add(btnRunCommand, buttonConstraints);
+
         JButton btnClearCommand = new JButton("Clear command");
         btnClearCommand.addActionListener((ActionEvent e) -> this.clearCommand());
-        buttonConstraints.gridy = 0;
+        buttonConstraints.gridy = 1;
         buttonPanel.add(btnClearCommand, buttonConstraints);
 
         JButton btnClearOrResetObservers = new JButton("Delete observers");
@@ -110,27 +115,27 @@ public class CommandManagerWindow extends JFrame implements WindowComponent {
             this.deleteObservers();
             this.toggleButtons(btnClearOrResetObservers);
         });
-        buttonConstraints.gridy = 1;
+        buttonConstraints.gridy = 2;
         buttonPanel.add(btnClearOrResetObservers, buttonConstraints);
 
         JButton btnClearPanel = new JButton("Clear Panel");
         btnClearPanel.addActionListener((ActionEvent e) -> this.clearPanel());
-        buttonConstraints.gridy = 2;
+        buttonConstraints.gridy = 3;
         buttonPanel.add(btnClearPanel, buttonConstraints);
 
         JButton btnPreviewCommand = new JButton("Preview Command");
         btnPreviewCommand.addActionListener((ActionEvent e) -> this.previewCommand());
-        buttonConstraints.gridy = 3;
+        buttonConstraints.gridy = 4;
         buttonPanel.add(btnPreviewCommand, buttonConstraints);
 
         JButton btnRefreshHistory = new JButton("Refresh Commands History");
         btnRefreshHistory.addActionListener((ActionEvent e) -> this.updateCommandHistoryField());
-        buttonConstraints.gridy = 4;
+        buttonConstraints.gridy = 5;
         buttonPanel.add(btnRefreshHistory, buttonConstraints);
 
         JButton btnRestoreCommand = new JButton("Restore Selected Command");
         btnRestoreCommand.addActionListener((ActionEvent e) -> this.restoreSelectedCommand());
-        buttonConstraints.gridy = 5;
+        buttonConstraints.gridy = 6;
         buttonPanel.add(btnRestoreCommand, buttonConstraints);
 
         leftConstraints.gridy = 4;
@@ -159,6 +164,11 @@ public class CommandManagerWindow extends JFrame implements WindowComponent {
         c.gridy = 0;
         c.weightx = 0.8;
         content.add(drawPanel, c);
+    }
+
+    private void runCommand(){
+        if (commandManager.getCurrentCommand() == null) return;
+        commandManager.getCurrentCommand().execute(commandManager.getDriver());
     }
 
     private void toggleButtons(JButton button) {

--- a/src/main/java/edu/kis/powp/jobs2d/command/manager/DriverCommandManager.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/manager/DriverCommandManager.java
@@ -13,7 +13,7 @@ import edu.kis.powp.observer.Publisher;
 /**
  * Driver command Manager.
  */
-public class DriverCommandManager {
+public class DriverCommandManager implements ICommandManager {
     private DriverCommand currentCommand = null;
 
     private final Publisher changePublisher = new Publisher();
@@ -25,13 +25,15 @@ public class DriverCommandManager {
      * 
      * @param commandList Set the command as current.
      */
+    @Override
     public synchronized void setCurrentCommand(DriverCommand commandList) {
         this.currentCommand = commandList;
         changePublisher.notifyObservers();
     }
 
-    public synchronized Job2dDriver getDriver() {
-        return DriverFeature.getDriverManager().getCurrentDriver();
+    @Override
+    public synchronized void runCommand() {
+        currentCommand.execute(DriverFeature.getDriverManager().getCurrentDriver());
     }
 
     /**
@@ -40,6 +42,7 @@ public class DriverCommandManager {
      * @param commandList list of commands representing a compound command.
      * @param name        name of the command.
      */
+    @Override
     public synchronized void setCurrentCommand(List<DriverCommand> commandList, String name) {
         setCurrentCommand(new ICompoundCommand() {
 
@@ -71,21 +74,24 @@ public class DriverCommandManager {
      *
      * @return Current command.
      */
+    @Override
     public synchronized DriverCommand getCurrentCommand() {
         return currentCommand;
     }
 
+    @Override
     public synchronized void clearCurrentCommand() {
         currentCommand = null;
     }
 
+    @Override
     public synchronized String getCurrentCommandString() {
         if (getCurrentCommand() == null) {
             return "No command loaded";
         } else
             return getCurrentCommand().toString();
     }
-
+    @Override
     public Publisher getChangePublisher() {
         return changePublisher;
     }

--- a/src/main/java/edu/kis/powp/jobs2d/command/manager/DriverCommandManager.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/manager/DriverCommandManager.java
@@ -6,8 +6,8 @@ import java.util.List;
 
 import edu.kis.powp.jobs2d.Job2dDriver;
 import edu.kis.powp.jobs2d.command.DriverCommand;
-import edu.kis.powp.jobs2d.command.DriverCommandVisitor;
 import edu.kis.powp.jobs2d.command.ICompoundCommand;
+import edu.kis.powp.jobs2d.features.DriverFeature;
 import edu.kis.powp.observer.Publisher;
 
 /**
@@ -16,7 +16,7 @@ import edu.kis.powp.observer.Publisher;
 public class DriverCommandManager {
     private DriverCommand currentCommand = null;
 
-    private Publisher changePublisher = new Publisher();
+    private final Publisher changePublisher = new Publisher();
 
     private final List<DriverCommand> commandHistory = new ArrayList<>();
 
@@ -30,6 +30,10 @@ public class DriverCommandManager {
         changePublisher.notifyObservers();
     }
 
+    public synchronized Job2dDriver getDriver() {
+        return DriverFeature.getDriverManager().getCurrentDriver();
+    }
+
     /**
      * Set current command.
      * 
@@ -39,7 +43,7 @@ public class DriverCommandManager {
     public synchronized void setCurrentCommand(List<DriverCommand> commandList, String name) {
         setCurrentCommand(new ICompoundCommand() {
 
-            List<DriverCommand> driverCommands = commandList;
+            final List<DriverCommand> driverCommands = commandList;
 
             @Override
             public void execute(Job2dDriver driver) {

--- a/src/main/java/edu/kis/powp/jobs2d/command/manager/ICommandManager.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/manager/ICommandManager.java
@@ -1,0 +1,22 @@
+package edu.kis.powp.jobs2d.command.manager;
+
+import edu.kis.powp.jobs2d.command.DriverCommand;
+import edu.kis.powp.observer.Publisher;
+
+import java.util.List;
+
+public interface ICommandManager {
+    void setCurrentCommand(DriverCommand commandList);
+
+    void runCommand();
+
+    void setCurrentCommand(List<DriverCommand> commandList, String name);
+
+    DriverCommand getCurrentCommand();
+
+    void clearCurrentCommand();
+
+    String getCurrentCommandString();
+
+    Publisher getChangePublisher();
+}


### PR DESCRIPTION
Added delete and reset functionality for observers, along with code cleanup.
Originally, a Run Command button was supposed to be added, but a Command Preview button had already been introduced earlier, which also executes the command.